### PR TITLE
Addition of Resize Handler

### DIFF
--- a/src/cookieconsent.js
+++ b/src/cookieconsent.js
@@ -399,6 +399,15 @@
       if (this.options.autoOpen) {
         this.autoOpen();
       }
+      
+      if (this.options.static) {
+        var thisObj = this;
+
+        window.onresize = function(event) {
+          var height = thisObj.element.clientHeight;
+          thisObj.element.parentNode.style.maxHeight = height + 'px';
+        };
+      }
     };
 
     CookiePopup.prototype.destroy = function() {


### PR DESCRIPTION
First-Timer with making a PR for an open source project, so apologies if I'm doing this wrong.

Absolutely love this project but a client request to change from the overlay to the static version exposed this little issue where the panel didn't update it's `max-height` if the browser was sized down.

So... I added a small resize handler to allow the max-height of the consent window to update on resize when in static mode.

Thoughts? Polishing?

Much appreciated!

Brian