### PR TITLE
Added parameter to disable forced floating

### DIFF
--- a/src/cookieconsent.js
+++ b/src/cookieconsent.js
@@ -383,6 +383,9 @@
       //     document.body.appendChild(instance.element);
       //
       autoAttach: true,
+	  
+	  // set value if floating layout should be forced for mobile devices
+	  forceFloating: true,
 
       // simple whitelist/blacklist for pages. specify page by:
       //   - using a string : '/index.html'           (matches '/index.html' exactly) OR
@@ -731,7 +734,7 @@
           ? 'banner'
           : 'floating';
 
-      if (util.isMobile()) {
+      if (util.isMobile() && opts.forceFloating) {
         positionStyle = 'floating';
       }
 


### PR DESCRIPTION
Hey there, as already discussed in #277 I would find it useful to disable the default behaviour which is forcing a floating banner on mobile devices. By default the current behaviour is preserved but it's now at least possible to adjust it via parameter.

