### PR TITLE
Fixed opt-in / opt-out markup

### DIFF
--- a/src/cookieconsent.js
+++ b/src/cookieconsent.js
@@ -296,9 +296,9 @@
       compliance: {
         info: '<div class="cc-compliance">{{dismiss}}</div>',
         'opt-in':
-          '<div class="cc-compliance cc-highlight">{{deny}}{{allow}}</div>',
+          '<div class="cc-compliance cc-highlight">{{dismiss}}{{allow}}</div>',
         'opt-out':
-          '<div class="cc-compliance cc-highlight">{{deny}}{{allow}}</div>'
+          '<div class="cc-compliance cc-highlight">{{deny}}{{dismiss}}</div>'
       },
 
       // select your type of popup here


### PR DESCRIPTION
I fixed the wrong markup for the `compliance` parameter and the options `opt-in` and `opt-out`. See also the discussion in https://github.com/insites/cookieconsent/issues/464. To me it looks like this was introduced with v3.1.0 because in previous versions the bug doesn't exist and also the corresponding lines are significantly different. Also it doesn't make sense how it currently is.

Thanks @dolav for determining the actual issue.