### PR TITLE
Add Norway to list of countries with cookie laws

### DIFF
--- a/src/cookieconsent.js
+++ b/src/cookieconsent.js
@@ -1589,6 +1589,7 @@
         'LU',
         'MT',
         'NL',
+        'NO',
         'PL',
         'PT',
         'SK',
@@ -1611,13 +1612,14 @@
         'LV',
         'LT',
         'NL',
+        'NO',
         'PT',
         'ES'
       ],
 
       // countries that say that a person can only "consent" if the explicitly click on "I agree".
       // in these countries, consent cannot be implied via a timeout or by scrolling down the page
-      explicitAction: ['HR', 'IT', 'ES']
+      explicitAction: ['HR', 'IT', 'ES', 'NO']
     };
 
     function Law(options) {


### PR DESCRIPTION
Hi! Nice library 👋

As a Norwegian I would like to add that Norway has implemented [GDPR (July 2018)](http://www.efta.int/EEA/news/General-Data-Protection-Regulation-GDPR-entered-force-EEA-509576) and has an own local cookie law from before [(Ekom 2-7b).](https://lovdata.no/dokument/NL/lov/2003-07-04-83/KAPITTEL_2#%C2%A72-7b)

As I read the *Ekom* law (about cookies), you don't need consent for "utelukkende for det formål å overføre kommunikasjon i et elektronisk kommunikasjonsnett"; directly translated "solely for the purpose of transmitting communication in a electronic communication network." If this is the case, you would not need cookie consent or warnings (but probably a privacy policy). If you store personal identifiable information in the cookies, you would need to be revokable and have explicit consent because of GDPR. If the cookie is used for other things than just delivering your service, you would need to have explicit consent because of Ekom (re-marketing etc).

I have therefore included ``'NO'`` in ``hasLaw``, ``revokable``,  and ``explicitAction``, as probably all are true if you have the need to implement a cookie consent popup.

The different scenarios and defaults should probably be second opinionated, as I am not a lawyer. But at least it's important to include Norway in the list of ``hasLaw`` because it now has two (as for July 2018 this year).