### PR TITLE
Added option to attach HTML as last element of body

### DIFF
--- a/src/cookieconsent.js
+++ b/src/cookieconsent.js
@@ -383,7 +383,10 @@
       //     document.body.appendChild(instance.element);
       //
       autoAttach: true,
-
+	  
+	  // If `attachBelow` is true, the created HTML will be attached as last element of the HTML body instead of the first element.
+	  attachBelow: false,
+	  
       // simple whitelist/blacklist for pages. specify page by:
       //   - using a string : '/index.html'           (matches '/index.html' exactly) OR
       //   - using RegExp   : /\/page_[\d]+\.html/    (matched '/page_1.html' and '/page_2.html' etc)
@@ -826,7 +829,7 @@
       el.addEventListener('click', this.onButtonClick);
 
       if (opts.autoAttach) {
-        if (!cont.firstChild) {
+        if (!cont.firstChild || opts.attachBelow) {
           cont.appendChild(el);
         } else {
           cont.insertBefore(el, cont.firstChild);


### PR DESCRIPTION
As discussed in #467 and #498 I suggest to extend the current functionality on where it is possible to attach the CookieConsent markup. I used a simple additional option parameter to achieve this. I know there is already the `container` parameter however it might be more convenient for users to handle this common situation directly without circumlocutions.

Hence I added `attachBelow` which by default is `false` (add as first element of the body) and can be used to attach the HTML right before the `</body>` tag. Thanks @jamieburchell for pointing on the issue and as this was a quick fix I decided to create a PR myself.

Update: As I noticed during revisiting this PR, with this parameter it is also possible to control the insertion position within a custom container element selected by the `container` parameter (first or last element).