### PR TITLE
fix expiry date calculation

### DIFF
--- a/src/cookieconsent.js
+++ b/src/cookieconsent.js
@@ -47,7 +47,7 @@
 
     setCookie: function(name, value, expiryDays, domain, path, secure) {
       var exdate = new Date();
-      exdate.setDate(exdate.getDate() + (expiryDays || 365));
+      exdate.setHours(exdate.getHours() + ((expiryDays || 365) * 24));
 
       var cookie = [
         name + '=' + value,


### PR DESCRIPTION
At least in current FireFox (66.0.3) the date calculation is broken
and leads for 26th April 2019 + 365 days to Wed Jun 06 2091 (72 years in the future).

See the following date calculation approaches with results:

var exdate = new Date();
exdate.setTime(exdate.getTime() + ((expiryDays || 365) * 24 * 60 * 60 * 1000));
console.log('exdate1 ' + exdate);

var exdate2 = new Date();
exdate2.setHours(exdate2.getHours() + ((expiryDays || 365) * 24));
console.log('exdate2 ' + exdate2);

var exdate3 = new Date();
exdate3.setDate(exdate3.getDate() + (expiryDays || 365));
console.log('exdate3 ' + exdate3);

exdate1 Sat Apr 25 2020 13:24:07 GMT+0200 (Central European Summer Time)
exdate2 Sat Apr 25 2020 13:24:07 GMT+0200 (Central European Summer Time)
exdate3 Wed Jun 06 2091 13:24:07 GMT+0200 (Central European Summer Time)