### PR TITLE
Fix handling of cc-dismiss

### DIFF
--- a/src/models/Popup.js
+++ b/src/models/Popup.js
@@ -462,7 +462,7 @@ export default class Popup extends Base {
       )
       const match = (matches && matches[1]) || false
       if (match) {
-        this.setStatuses(match)
+        this.setStatuses(match.toUpperCase())
         this.close(true)
       }
     }


### PR DESCRIPTION
This applies when CookieConsent is initialized with the following settings:
```
new CookieConsent({
          cookie: { domain: ".mydomain.com", secure: true },
          theme: "edgeless",
          position: "top",
          static: true,
        }),
```

This causes a simple bar to show at the top. The "Got it!" button has a class `cc-dismiss` set.

There's no special case for `cc-dismiss` in `handleButtonClick`, the handler called when the button is clicked. This causes the function to fall back to a regular expression matching all the possible statuses (`deny`, `allow`, `dismiss`), however in lowercase. A match is found, but the match text (`dismiss`) is passed to `setStatuses` directly in lowercase as it was matched, instead of being uppercased again.

This causes the validity check to fail in the `setStatuses` function because it expects `DISMISS` instead of `dismiss` and the cookie isn't set, creating a frustrating situation for the user where even after dismissing the popup, it will keep showing on each visit.