### PR TITLE
Fix revokeButton appear after set revokable and regionalLaw to false

### DIFF
--- a/src/models/Popup.js
+++ b/src/models/Popup.js
@@ -581,7 +581,7 @@ export default class Popup extends Base {
 
   applyRevokeButton() {
     // revokable is true if advanced compliance is selected
-    if (this.options.type != 'info') this.options.revokable = true
+    if (this.options.type != 'info' && this.options.regionalLaw == true) this.options.revokable = true
     // animateRevokable false for mobile devices
     if (isMobile()) this.options.animateRevokable = false
 


### PR DESCRIPTION
Hi, folks!

When you set:
```
revokable: false,
law: { regionalLaw: false }
```
the `revokeButton` still appear, because there wasn't a verification checking `regionalLaw` inside the first `if`, in `applyRevokeButton()`.

So, this PR is to apply this check and fix the problem.

There is an open issue https://github.com/osano/cookieconsent/issues/637 talking about this bug.