### PR TITLE
fix: "o.path is undefined" in firefox and edge

### DIFF
--- a/src/cookieconsent.js
+++ b/src/cookieconsent.js
@@ -1052,7 +1052,8 @@
       if (windowClick) {
         var onWindowClick = function(evt) {
           var isIgnored = false;
-          var pathLen = evt.path.length;
+          var eventPath = (evt.composedPath && evt.composedPath()) || evt.path;
+          var pathLen = eventPath.length;
           var ignoredLen = ignoredClicks.length;
           for (var i = 0; i < pathLen; i++) {
             if (isIgnored) continue;
@@ -1060,7 +1061,7 @@
             for (var i2 = 0; i2 < ignoredLen; i2++) {
               if (isIgnored) continue;
 
-              isIgnored = util.hasClass(evt.path[i], ignoredClicks[i2]);
+              isIgnored = util.hasClass(eventPath[i], ignoredClicks[i2]);
             }
           }
 


### PR DESCRIPTION
This PR try to fixes the error cause by `event.path` not supported in Firefox.

I did see that is already resolved in v4, but currently we cannot currently use that version in production.