### PR TITLE
implements the "SameSite"-attribute for the Consent-Cookie

### DIFF
--- a/src/bundle.js
+++ b/src/bundle.js
@@ -923,7 +923,7 @@ function addStyle (obj, options) {
 	// If a transform function was defined, run it on the css
 	if (options.transform && obj.css) {
 	    result = typeof options.transform === 'function'
-		 ? options.transform(obj.css) 
+		 ? options.transform(obj.css)
 		 : options.transform.default(obj.css);
 
 	    if (result) {
@@ -1905,7 +1905,7 @@ class Popup extends _Base__WEBPACK_IMPORTED_MODULE_0__["default"] {
       this.toggleRevokeButton(true);
     }
   }
-  /** 
+  /**
    * Set's cookie statuses
    * @param { string<status> } allOrUndef      - If this is the only param, set ALL if not, set Uncategorized cookies statuses set to value.
    * @param { string<status> } essential       - Essential Cookies status set to value
@@ -1922,14 +1922,15 @@ class Popup extends _Base__WEBPACK_IMPORTED_MODULE_0__["default"] {
       expiryDays,
       domain,
       path,
-      secure
+      secure,
+      sameSite
     } = this.options.cookie;
 
     const updateCategoryStatus = (categoryName, status) => {
       if (Object(_utils__WEBPACK_IMPORTED_MODULE_3__["isValidStatus"])(status)) {
         const cookieName = name + '_' + categoryName;
         const chosenBefore = _constants__WEBPACK_IMPORTED_MODULE_2__["statuses"].indexOf(Object(_utils__WEBPACK_IMPORTED_MODULE_3__["getCookie"])(cookieName)) >= 0;
-        Object(_utils__WEBPACK_IMPORTED_MODULE_3__["setCookie"])(cookieName, status, expiryDays, domain, path, secure);
+        Object(_utils__WEBPACK_IMPORTED_MODULE_3__["setCookie"])(cookieName, status, expiryDays, domain, path, secure, sameSite);
         this.emit("statusChanged", cookieName, status, chosenBefore);
       } else {
         this.clearStatuses();
@@ -2485,7 +2486,9 @@ __webpack_require__.r(__webpack_exports__);
     // The cookies expire date, specified in days (specify -1 for no expiry)
     expiryDays: 365,
     // If true the cookie will be created with the secure flag. Secure cookies will only be transmitted via HTTPS.
-    secure: false
+    secure: false,
+    // Sets the "sameSite"-Attribute of the `cookieconsent_status`-Cookie allowed attributes are "Lax", "Strict" and "None" ("None" is only allowed with the `Secure`-flag)
+    sameSite: null
   },
   // each item defines the inner text for the element that it references
   content: {
@@ -2741,10 +2744,10 @@ const getCookie = name => {
   const parts = value.split(' ' + name + '=');
   return parts.length < 2 ? undefined : parts.pop().split(';').shift();
 };
-const setCookie = function (name, value, expiryDays, domain, path, secure) {
+const setCookie = function (name, value, expiryDays, domain, path, secure, sameSite) {
   const exdate = new Date();
   exdate.setHours(exdate.getHours() + (typeof expiryDays !== "number" ? 365 : expiryDays) * 24);
-  document.cookie = name + '=' + value + ';expires=' + exdate.toUTCString() + ';path=' + (path || '/') + (domain ? ';domain=' + domain : '') + (secure ? ';secure' : '');
+  document.cookie = name + '=' + value + ';expires=' + exdate.toUTCString() + ';path=' + (path || '/') + (domain ? ';domain=' + domain : '') + (secure ? ';secure' : '') + (sameSite ? ';sameSite=' + sameSite : '');
 };
 
 /***/ }),

--- a/src/models/Popup.js
+++ b/src/models/Popup.js
@@ -41,7 +41,7 @@ export default class Popup extends Base {
         MozT: 'transitionend',
         WebkitT: 'webkitTransitionEnd'
       }
-  
+
       for (let prefix in trans) {
         if (
           trans.hasOwnProperty(prefix) &&
@@ -79,7 +79,7 @@ export default class Popup extends Base {
 
     // if static, we need to grow the element from 0 height so it doesn't jump the page
     // content. we wrap an element around it which will mask the hidden content
-    
+
     if (this.options.static) {
       // `grower` is a wrapper div with a hidden overflow whose height is animated
       const wrapper = this.appendMarkup(`<div class="cc-grower">${cookiePopup}</div>`)
@@ -121,7 +121,7 @@ export default class Popup extends Base {
 
   close( showRevoke ) {
     if (!this.element) return
-    
+
     if (this.isOpen()) {
       if (this.hasTransition) {
         this.fadeOut()
@@ -179,7 +179,7 @@ export default class Popup extends Base {
     this.openingTimeout = null
     element.classList.remove('cc-invisible')
   }
-  
+
   fadeOut() {
     if (!this.hasTransition || !this.element) return
 
@@ -199,7 +199,7 @@ export default class Popup extends Base {
       this.element.classList.add('cc-invisible')
     }
   }
-  
+
   afterFadeOut(el) {
     el.style.display = 'none' // after close and before open, the display should be none
     el.removeEventListener(this.transitionEnd, this.afterTransition)
@@ -255,7 +255,7 @@ export default class Popup extends Base {
     }
   }
 
-  /** 
+  /**
    * Set's cookie statuses
    * @param { string<status> } allOrUndef      - If this is the only param, set ALL if not, set Uncategorized cookies statuses set to value.
    * @param { string<status> } essential       - Essential Cookies status set to value
@@ -265,13 +265,13 @@ export default class Popup extends Base {
    * @return { undefined }
   */
   setStatuses() {
-    const { name, expiryDays, domain, path, secure } = this.options.cookie
+    const { name, expiryDays, domain, path, secure, sameSite } = this.options.cookie
 
     const updateCategoryStatus = ( categoryName, status ) => {
       if (isValidStatus(status)) {
         const cookieName = name+'_'+categoryName
         const chosenBefore = statuses.indexOf( getCookie(cookieName) ) >= 0
-        setCookie(cookieName, status, expiryDays, domain, path, secure)
+        setCookie(cookieName, status, expiryDays, domain, path, secure, sameSite)
         this.emit( "statusChanged", cookieName, status, chosenBefore )
       } else {
         this.clearStatuses()
@@ -305,7 +305,7 @@ export default class Popup extends Base {
       setCookie(name+'_'+categoryName, '', -1, domain, path)
     })
   }
-  
+
   canUseCookies() {
     if (!window.navigator.cookieEnabled || window.CookiesOK || window.navigator.CookiesOK ) {
       return true
@@ -366,7 +366,7 @@ export default class Popup extends Base {
 
     // removes link if showLink is false
     if (!opts.showLink) {
-      opts.elements.link = '' 
+      opts.elements.link = ''
       opts.elements.messagelink = opts.elements.message
     }
 
@@ -394,7 +394,7 @@ export default class Popup extends Base {
     if (!layout) {
       layout = opts.layouts.basic
     }
-    
+
     return interpolateString(layout, match =>interpolated[match] )
   }
 
@@ -450,7 +450,7 @@ export default class Popup extends Base {
   handleButtonClick(event) {
     // returns the parent element with the specified class, or the original element - null if not found
     const btn = traverseDOMPath(event.target, 'cc-btn') || event.target
-    
+
     if (btn.classList.contains( 'cc-btn' ) && btn.classList.contains( 'cc-save' )){
       this.setStatuses()
       this.close(true)
@@ -544,7 +544,7 @@ export default class Popup extends Base {
           ) {
             this.setStatuses(statusDismiss)
             this.close(true)
-            
+
             window.removeEventListener('click', this.onWindowClick)
             window.removeEventListener('touchend', this.onWindowClick)
             this.onWindowClick = null

--- a/src/models/Popup.spec.js
+++ b/src/models/Popup.spec.js
@@ -59,7 +59,8 @@ describe( "Popup Class", () => {
       cookie   : {
         name  : "test_cookie",
         comain: "me.selfdomain.com",
-        secure: true
+        secure: true,
+        sameSite: "Lax"
       },
       content  : {
         message: "test message"

--- a/src/options/popup.js
+++ b/src/options/popup.js
@@ -21,7 +21,9 @@ export default {
     // The cookies expire date, specified in days (specify -1 for no expiry)
     expiryDays: 365,
     // If true the cookie will be created with the secure flag. Secure cookies will only be transmitted via HTTPS.
-    secure: false
+    secure: false,
+    // Sets the "sameSite"-Attribute of the `cookieconsent_status`-Cookie allowed attributes are "Lax", "Strict" and "None" ("None" is only allowed with the `Secure`-flag)
+    sameSite: null
   },
 
   // each item defines the inner text for the element that it references
@@ -79,7 +81,7 @@ export default {
   //  - {{children}} is where the HTML children are placed
   window:
     '<div role="dialog" aria-live="polite" aria-label="cookieconsent" aria-describedby="cookieconsent:desc" class="cc-window {{classes}}"><!--googleoff: all-->{{children}}<!--googleon: all--></div>',
-  
+
   modal: '',
 
   // This is the html for the revoke button. This only shows up after the user has selected their level of consent

--- a/src/utils/cookie.js
+++ b/src/utils/cookie.js
@@ -11,12 +11,13 @@ export const getCookie = name => {
         .shift()
 }
 
-export const setCookie = function ( name, value, expiryDays, domain, path, secure ) {
+export const setCookie = function ( name, value, expiryDays, domain, path, secure, sameSite ) {
   const exdate = new Date()
   exdate.setHours(exdate.getHours() + ((typeof expiryDays !== "number"  ? 365 : expiryDays ) * 24))
   document.cookie = name + '=' + value +
                     ';expires=' + exdate.toUTCString() +
                     ';path=' + (path || '/') +
                     ( domain ? ';domain=' + domain : '' ) +
-                    ( secure ? ';secure' : '' )
+                    ( secure ? ';secure' : '' ) +
+                    ( sameSite ? ';sameSite=' + sameSite : '' );
 }


### PR DESCRIPTION
- adds the parameter `sameSite` to the `setCookie()`-Function
- implements the attribute `sameSite` in the `defaultOptions`-Object (defaultOptions.cookie.sameSite) with the default value of `null` (allowed is `None`, `Lax` and `Strict`)
- More information: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite