### PR TITLE
transitionEnd not defined, nasty bug

### DIFF
--- a/src/models/Popup.js
+++ b/src/models/Popup.js
@@ -32,7 +32,7 @@ export default class Popup extends Base {
       MARKETING      : 'DISMISS'
     }
     this.customStyles = {}
-    this.hasTransition = !!(function() {
+    this.transitionEnd = (function() {
       const el = document.createElement('div')
       const trans = {
         t: 'transitionend',
@@ -52,6 +52,7 @@ export default class Popup extends Base {
       }
       return ''
     })()
+    this.hasTransition = !!this.transitionEnd;
 
     // returns true if `onComplete` was called
     if (this.canUseCookies()) {


### PR DESCRIPTION
hasTransition is defined in the object, but transitionEnd is not.
This is a regression from previous behavior.

What this causes is the cookie dialog to disappear to opacity:0 but remain active in the DOM. It steals focus from anything under it, including form buttons.