### PR TITLE
Add IP2Location.io API

### DIFF
--- a/src/options/location.js
+++ b/src/options/location.js
@@ -38,7 +38,7 @@ export default {
     ipinfo: function() {
       return {
         // This service responds with JSON, so we simply need to parse it and return the country code
-        url: '//ipinfo.io',
+        url: '//ipinfo.io/json',
         headers: ['Accept: application/json'],
         callback: function(done, response) {
           try {
@@ -75,6 +75,27 @@ export default {
           }
         }
       }
+    },
+
+    // This service requires an option to define `key`. Options are proived using objects or functions
+    ip2locationio: function () {
+      return {
+        // This service responds with JSON, so we simply need to parse it and return the country code
+        url: 'https://api.ip2location.io/?key={api_key}&format=json',
+        headers: ['Accept: application/json'],
+        callback: function (done, response) {
+          try {
+            const json = JSON.parse(response);
+            return json.error ? toError(json) : {
+              code: json.country_code
+            };
+          } catch (err) {
+            return toError({
+              error: 'Invalid response (' + err + ')'
+            });
+          }
+        }
+      };
     },
 
     maxmind: function() {

--- a/src/options/location.js
+++ b/src/options/location.js
@@ -38,7 +38,7 @@ export default {
     ipinfo: function() {
       return {
         // This service responds with JSON, so we simply need to parse it and return the country code
-        url: '//ipinfo.io/json',
+        url: '//ipinfo.io',
         headers: ['Accept: application/json'],
         callback: function(done, response) {
           try {
@@ -78,6 +78,7 @@ export default {
     },
 
     // This service requires an option to define `key`. Options are proived using objects or functions
+    // User can sign up for the free api key at here: https://www.ip2location.io/sign-up
     ip2locationio: function () {
       return {
         // This service responds with JSON, so we simply need to parse it and return the country code


### PR DESCRIPTION
Add IP2Location.io API into location.js. IP2Location.io provides a fast and accurate IP Geolocation API tool, and it provides a free plan to use. User can register for a free API key through [https://www.ip2location.io/sign-up](https://www.ip2location.io/sign-up). For more information about the API, kindly visit the documentation at here: https://www.ip2location.io/ip2location-documentation